### PR TITLE
Modified parser for command line

### DIFF
--- a/gyft.py
+++ b/gyft.py
@@ -9,7 +9,7 @@ import getpass
 #### Parsing from commmand line
 import argparse
 parser = argparse.ArgumentParser()
-parser.add_argument('-user', type = str, help = "Username")
+parser.add_argument("-u", "--user", help="ERP Username/Login ID")
 args = parser.parse_args()
 erp_password = getpass.getpass("Enter your ERP password: ")
 

--- a/gyft.py
+++ b/gyft.py
@@ -10,8 +10,9 @@ import getpass
 import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument('-user', type = str, help = "Username")
-erp_password = getpass.getpass("Enter your ERP password: ")
 args = parser.parse_args()
+erp_password = getpass.getpass("Enter your ERP password: ")
+
 #### Parsing ends
 
 ERP_HOMEPAGE_URL = 'https://erp.iitkgp.ernet.in/IIT_ERP3/'


### PR DESCRIPTION
- [x] fixes #20 
- [x] optional argument naming in accordance with UNIX
- [x] adds short optional argument for `--user`: `-u`
- [x] removing `type` parameter as its deafult value is `str`
- [x] improved description of `--user` optional argument

Ping @nishnik @athityakumar 