### PR TITLE
Bug empty day

### DIFF
--- a/dates.py
+++ b/dates.py
@@ -6,13 +6,13 @@ import pytz
 import sys
 
 # SEM_BEGIN=datetime.datetime.now(pytz.timezone('Asia/Kolkata'))
-SEM_BEGIN=build_event.generateIndiaTime(2018, 7, 17, 0, 0)
+SEM_BEGIN = build_event.generateIndiaTime(2019, 1, 1, 0, 0)
 
-MID_TERM_BEGIN=build_event.generateIndiaTime(2018, 9, 17, 0, 0)
+MID_TERM_BEGIN = build_event.generateIndiaTime(2019, 2, 17, 0, 0)
 
-MID_TERM_END=build_event.generateIndiaTime(2018, 9, 26, 23, 59)
+MID_TERM_END = build_event.generateIndiaTime(2019, 2, 26, 23, 59)
 
-END_TERM_BEGIN=build_event.generateIndiaTime(2018, 11, 16, 0, 0)
+END_TERM_BEGIN = build_event.generateIndiaTime(2019, 4, 21, 0, 0)
 
 ## Sanity check
 

--- a/gyft.py
+++ b/gyft.py
@@ -111,6 +111,8 @@ for i in range(1, len(rows)):
     tds = rows[i].findAll('td')
     time = 0
     for a in range(1, len(tds)):
+        if not tds[a].find('b'):
+            continue
         txt = tds[a].find('b').text.strip()
         if (len(txt) >= 7):
             timetable_dict[days[i]][times[time]] = list((tds[a].find('b').text[:7],tds[a].find('b').text[7:], int(tds[a]._attr_value_as_string('colspan'))))


### PR DESCRIPTION
This fixes #55 

The Bug happens if there are no events on a particular day. The text field thus is empty and it returns None instead. This is fixed by skipping the days if no event is found.

I have tested this solution with my timetable which had a day empty.