### PR TITLE
Update gyft.py

### DIFF
--- a/gyft.py
+++ b/gyft.py
@@ -118,10 +118,14 @@ for i in range(1, len(rows)):
             continue
         txt = tds[a].find('b').text.strip()
         if (len(txt) >= 7):
-            timetable_dict[days[i]][times[time]] = list((tds[a].find('b').text[:7],tds[a].find('b').text[7:], int(tds[a]._attr_value_as_string('colspan'))))
-        time = time + int(tds[a]._attr_value_as_string('colspan'))
-
-
+            timetable_dict[days[i]][times[time]] = list(
+                (
+                    tds[a].find('b').text[:7],
+                    tds[a].find('b').text[7:],
+                    int(tds[a].attrs['colspan'])
+                )
+            )
+        time = time + int(tds[a].attrs['colspan'])
 def merge_slots(in_dict):
     for a in in_dict:
         in_dict[a] = sorted(in_dict[a])


### PR DESCRIPTION
line 121 :
`...  int(tds[a]._attr_value_as_string('colspan'))))`
as well as line 122 :
` time = time + int(tds[a]._attr_value_as_string('colspan'))`

`_attr_value_as_string('colspan')` returns a `NoneType` object which is non callable

Apparently, there's no such method as `tag_name._attr_value_as_string('attr_name')` to extract attribute values of HTML tags.

Although, according to https://www.crummy.com/software/BeautifulSoup/bs4/doc/#attributes `tag_name.attrs` is a valid method to extract the attribute value of any tag by treating it like a dictionary, which I have utilised in the PR.
![image](https://user-images.githubusercontent.com/67605729/151572839-18209dfc-b655-4835-b4b8-31227d8d3c2c.png)

