### PR TITLE
Much better scraping of course names

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The following procedure is to be followed each new semester by the maintainer fo
   ```
 
   ```sh
-  $ python3 gyft.py
+  $ python3 gyft.py --user <ROLL_NUMBER> --sem <CURRENT_SEM_NUMBER>
   ```
 
   Enter your password and security answer when prompted.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The following procedure is to be followed each new semester by the maintainer fo
   ```
 
   ```sh
-  $ python3 gyft.py --user <ROLL_NUMBER> --sem <CURRENT_SEM_NUMBER>
+  $ python3 gyft.py --user <ROLL_NUMBER>
   ```
 
   Enter your password and security answer when prompted.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The following procedure is to be followed each new semester by the maintainer fo
   ```
 
   ```sh
-  $ python3 gyft.py --user <ROLL_NUMBER>
+  $ python3 gyft.py 
   ```
 
   Enter your password and security answer when prompted.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The following procedure is to be followed each new semester by the maintainer fo
   
   **Use the web application on any browser**
 
-  - Go to the [GYFT WebApp](https://gyftkgp.herokuapp.com/).
+  - Go to the [GYFT WebApp](https://gyft.metakgp.org/).
   - Enter your roll number and get the security question.
   - Once the security question is fetched, enter your credentials and save the ICS file.
   - Move to step 2(b)(ii).

--- a/gyft.py
+++ b/gyft.py
@@ -150,4 +150,4 @@ for day in timetable_dict.keys():
 with open('data.txt', 'w') as outfile:
     json.dump(timetable_dict, outfile, indent = 4, ensure_ascii=False)
 
-print ("\nTimetable saved to data.txt file. Be sure to edit this file to have desired names of subjects rather than subject codes.\n")
+print ("\nTimetable saved to data.txt file. You can generate the ICS file now by running generate_ics.py.\n")

--- a/gyft.py
+++ b/gyft.py
@@ -5,8 +5,18 @@ from bs4 import BeautifulSoup as bs
 import json
 import iitkgp_erp_login.erp as erp
 import logging
+import argparse
 
+parser = argparse.ArgumentParser(description='Generate ICS file for IIT KGP timetable.')
+parser.add_argument('--user', help='Roll number')
+parser.add_argument('--sem', help='Current Semester Number')
 
+args = parser.parse_args()
+
+if args.user is None:
+    args.user = input("Enter your roll number: ")
+if args.sem is None:
+    args.sem = input("Enter your current semester number: ")
 
 headers = {
     'timeout': '20',
@@ -20,12 +30,19 @@ print()
 
 
 ERP_TIMETABLE_URL = "https://erp.iitkgp.ac.in/Acad/student/view_stud_time_table.jsp"
-COURSES_URL = "https://erp.iitkgp.ac.in/Acad/timetable_track.jsp?action=second&dept={}"
+COURSES_URL = "https://erp.iitkgp.ac.in/Academic/student_performance_details_ug.htm"
 
 timetable_details = {
     'ssoToken': ssoToken,
     'module_id': '16',
     'menu_id': '40',
+}
+
+coursepage_details = {
+    "ssoToken": ssoToken,
+    "semno": args.sem,
+    "rollno": args.user,
+    "order": "asc"
 }
 
 # This is just a hack to get cookies. TODO: do the standard thing here
@@ -50,7 +67,6 @@ times = []
 del_rows = []
 for i in range(1, len(rows)):
     HeaderRows = rows[i].findAll("td", {"class": "tableheader"})
-    # print(HeaderRows)
     if len(HeaderRows) == 0:
         del_rows.append(i)
 
@@ -120,46 +136,16 @@ for day in timetable_dict.keys():
         else:
             timetable_dict[day][time][2] = subject_timings[timetable_dict[day][time][0]][1]
 
-courses = {}
-# grouping courses by dept
-for day in timetable_dict.keys():
-    for time in timetable_dict[day]:
-        timetable_dict[day][time].append(" ")
-        course_code = timetable_dict[day][time][0]
-        course_dept = course_code[:2]
-        if course_dept not in courses.keys():
-            courses[course_dept] = {}
-        if course_code not in courses[course_dept].keys():
-            courses[course_dept][course_code] = ''
-
-# scraping course names deptwise
-for dept in courses.keys():
-    DEPT_URL = COURSES_URL.format(dept)
-    r = s.get(DEPT_URL, headers=headers)
-    soup = bs(r.text, 'html.parser')
-    parentTable = soup.find('table', {'id': 'disptab'})
-
-    rows = parentTable.find_all('tr')
-
-    for row in rows[1:]:
-        if 'bgcolor' in row.attrs:
-            continue 
-        cells = row.find_all('td')  
-        course_code = cells[0].text.strip()
-        course_name = cells[1].text.strip()
-
-        if course_code in courses[dept]:
-            courses[dept][course_code] = course_name
-            logging.info(" {} - {}".format(course_code, course_name))
+r = s.post(COURSES_URL, headers=headers, data=coursepage_details)
+sub_dict = {item["subno"]: item["subname"] for item in r.json()}
+sub_dict = {k: v.replace("&amp;", "&") for k, v in sub_dict.items()} # replacing &amp; with &
 
 
-# add course code to dict
+# add course name to dict
 for day in timetable_dict.keys():
     for time in timetable_dict[day]:
         course_code = timetable_dict[day][time][0]
-        course_dept = course_code[:2]
-        timetable_dict[day][time][3] = courses[course_dept][course_code]
-
+        timetable_dict[day][time].append(sub_dict[course_code])
 
 with open('data.txt', 'w') as outfile:
     json.dump(timetable_dict, outfile, indent = 4, ensure_ascii=False)

--- a/gyft.py
+++ b/gyft.py
@@ -4,25 +4,7 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 from bs4 import BeautifulSoup as bs
 import json
 import iitkgp_erp_login.erp as erp
-import logging
-import argparse
 from dates import SEM_BEGIN
-
-parser = argparse.ArgumentParser(description='Generate ICS file for IIT KGP timetable.')
-parser.add_argument('--user', help='Roll number')
-
-args = parser.parse_args()
-
-if args.user is None:
-    args.user = input("Enter your roll number: ")
-
-if SEM_BEGIN.month > 6:
-    # autumn semester
-    SEM_NO = (int(SEM_BEGIN.strftime("%y"))-int(args.user[:2]))*2 + 1
-else:
-    # spring semester
-    SEM_NO = (int(SEM_BEGIN.strftime("%y"))-int(args.user[:2])) + 2
-
 
 headers = {
     'timeout': '20',
@@ -33,6 +15,13 @@ s = requests.Session()
 
 _, ssoToken = erp.login(headers, s)
 print()
+
+if SEM_BEGIN.month > 6:
+    # autumn semester
+    SEM_NO = (int(SEM_BEGIN.strftime("%y"))-int(erp.ROLL_NUMBER[:2]))*2 + 1
+else:
+    # spring semester
+    SEM_NO = (int(SEM_BEGIN.strftime("%y"))-int(erp.ROLL_NUMBER[:2])) + 2
 
 
 ERP_TIMETABLE_URL = "https://erp.iitkgp.ac.in/Acad/student/view_stud_time_table.jsp"
@@ -47,7 +36,7 @@ timetable_details = {
 coursepage_details = {
     "ssoToken": ssoToken,
     "semno": SEM_NO,
-    "rollno": args.user,
+    "rollno": erp.ROLL_NUMBER,
     "order": "asc"
 }
 

--- a/gyft.py
+++ b/gyft.py
@@ -6,17 +6,23 @@ import json
 import iitkgp_erp_login.erp as erp
 import logging
 import argparse
+from dates import SEM_BEGIN
 
 parser = argparse.ArgumentParser(description='Generate ICS file for IIT KGP timetable.')
 parser.add_argument('--user', help='Roll number')
-parser.add_argument('--sem', help='Current Semester Number')
 
 args = parser.parse_args()
 
 if args.user is None:
     args.user = input("Enter your roll number: ")
-if args.sem is None:
-    args.sem = input("Enter your current semester number: ")
+
+if SEM_BEGIN.month > 6:
+    # autumn semester
+    SEM_NO = (int(SEM_BEGIN.strftime("%y"))-int(args.user[:2]))*2 + 1
+else:
+    # spring semester
+    SEM_NO = (int(SEM_BEGIN.strftime("%y"))-int(args.user[:2])) + 2
+
 
 headers = {
     'timeout': '20',
@@ -40,7 +46,7 @@ timetable_details = {
 
 coursepage_details = {
     "ssoToken": ssoToken,
-    "semno": args.sem,
+    "semno": SEM_NO,
     "rollno": args.user,
     "order": "asc"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ beautifulsoup4==4.12.2
 google_api_python_client==2.90.0
 httplib2==0.22.0
 icalendar==5.0.7
-iitkgp_erp_login==2.2.0
+iitkgp_erp_login==2.2.1
 oauth2client==4.1.3
 pytz==2023.3
 Requests==2.31.0


### PR DESCRIPTION
Now the course names are directly scraped from `Student -> Your Academic Information -> Performance New` (basically the same page where you check SG and CG), so now it scrapes _only_ your courses and doesn't have to go through all the courses. 

<img width="1131" alt="image" src="https://github.com/metakgp/gyft/assets/62993493/72fbba5b-2894-4dc7-b171-629795140314">

Only issue is that now user has to provide their current semester number and roll number:
- Semester number is calculated using roll number and sem begin date 
- Roll number is obtained from the user credentials obtained during login
