### PR TITLE
Update timetable url to point to new endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@
 
 Gets your timetable from ERP and adds it to your Google Calendar or gives you an ICS file which you can add in any common calendar application.
 
-> **Note** All updates to this repo should reflect, with appropriate refactorisation, in [gyft-serve](https://github.com/metakgp/gyft-serve/)
-
 <p align="right">(<a href="#top">back to top</a>)</p>
 
 <!-- GETTING STARTED -->

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@
 
 Gets your timetable from ERP and adds it to your Google Calendar or gives you an ICS file which you can add in any common calendar application.
 
+> **Note** All updates to this repo should reflect, with appropriate refactorisation, in [gyft-serve](https://github.com/metakgp/gyft-serve/)
+
 <p align="right">(<a href="#top">back to top</a>)</p>
 
 <!-- GETTING STARTED -->

--- a/gyft.py
+++ b/gyft.py
@@ -63,7 +63,7 @@ def main():
 
 def get_courses(session: requests.Session, sso_token: str, roll_number: str):
 
-    erp_timetable_url = "https://erp.iitkgp.ac.in/Acad/student/view_stud_time_table.jsp"
+    erp_timetable_url = "https://erp.iitkgp.ac.in/Acad/student/student_timetable.jsp"
     courses_url: str = (
         "https://erp.iitkgp.ac.in/Academic/student_performance_details_ug.htm?semno={}&rollno={}"
     )


### PR DESCRIPTION
Fixes #143 

Origin of error: Since this semester, ERP serves up the timetable on a new endpoint (`/student_timetable.jsp`). It just so happens that the old endpoint (`view_stud_time_table.jsp`) still works for everyone except first year students, for whom only the new endpoint works.